### PR TITLE
write: use filepath instead of path to fix problems under Windows

### DIFF
--- a/tz/tz_test.go
+++ b/tz/tz_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -89,12 +91,15 @@ func TestAddEmptyDir(t *testing.T) {
 
 func TestAddDir(t *testing.T) {
 	Convey("Open a tar.gz file and add dir with files", t, func() {
-		z, err := Create(path.Join(os.TempDir(), "testdata/TestAddDir.tar.gz"))
+		z, err := Create(filepath.Join(os.TempDir(), "testdata/TestAddDir.tar.gz"))
 		So(err, ShouldBeNil)
 
 		Convey("Add a dir that does exist", func() {
 			So(z.AddDir("testdata/testdir", "testdata/testdir"), ShouldBeNil)
-			So(strings.Join(z.List(), " "), ShouldEqual,
+
+			list := z.List()
+			sort.Strings(list)
+			So(strings.Join(list, " "), ShouldEqual,
 				"testdata/ testdata/testdir/ testdata/testdir/gophercolor16x16.png"+
 					" testdata/testdir/level1/ testdata/testdir/level1/README.txt")
 		})

--- a/tz/write.go
+++ b/tz/write.go
@@ -182,22 +182,22 @@ func (tz *TzArchive) Flush() (err error) {
 	}
 
 	// Extract to tmp path and pack back.
-	tmpPath := path.Join(os.TempDir(), "cae", path.Base(tz.FileName))
-	os.RemoveAll(tmpPath)
-	os.MkdirAll(tmpPath, os.ModePerm)
-	defer os.RemoveAll(tmpPath)
+	tmpPath := filepath.Join(os.TempDir(), "cae", filepath.Base(tz.FileName))
+	_ = os.RemoveAll(tmpPath)
+	_ = os.MkdirAll(tmpPath, os.ModePerm)
+	defer func() { _ = os.RemoveAll(tmpPath) }()
 
 	// Copy post-added files.
 	for _, f := range tz.files {
 		if strings.HasSuffix(f.Name, "/") {
-			os.MkdirAll(path.Join(tmpPath, f.Name), os.ModePerm)
+			_ = os.MkdirAll(filepath.Join(tmpPath, f.Name), os.ModePerm)
 			continue
 		} else if !cae.IsExist(f.absPath) {
 			continue
 		}
 
-		relPath := path.Join(tmpPath, f.Name)
-		os.MkdirAll(path.Dir(relPath), os.ModePerm)
+		relPath := filepath.Join(tmpPath, f.Name)
+		_ = os.MkdirAll(filepath.Dir(relPath), os.ModePerm)
 		if err := cae.Copy(relPath, f.absPath); err != nil {
 			return err
 		}
@@ -356,7 +356,7 @@ func packToWriter(srcPath string, w io.Writer, fn func(fullName string, fi os.Fi
 		return err
 	}
 
-	basePath := path.Base(srcPath)
+	basePath := filepath.Base(srcPath)
 
 	if fi.IsDir() {
 		if includeDir {

--- a/zip/write.go
+++ b/zip/write.go
@@ -167,18 +167,18 @@ func (z *ZipArchive) Flush() error {
 	}
 
 	// Extract to tmp path and pack back.
-	tmpPath := path.Join(os.TempDir(), "cae", path.Base(z.FileName))
-	os.RemoveAll(tmpPath)
-	defer os.RemoveAll(tmpPath)
+	tmpPath := filepath.Join(os.TempDir(), "cae", filepath.Base(z.FileName))
+	_ = os.RemoveAll(tmpPath)
+	defer func() { _ = os.RemoveAll(tmpPath) }()
 
 	for _, f := range z.files {
 		if strings.HasSuffix(f.Name, "/") {
-			os.MkdirAll(path.Join(tmpPath, f.Name), os.ModePerm)
+			_ = os.MkdirAll(filepath.Join(tmpPath, f.Name), os.ModePerm)
 			continue
 		}
 
 		// Relative path inside zip temporary changed.
-		f.tmpPath = path.Join(tmpPath, f.Name)
+		f.tmpPath = filepath.Join(tmpPath, f.Name)
 		if err := z.extractFile(f); err != nil {
 			return err
 		}
@@ -295,7 +295,7 @@ func packToWriter(srcPath string, w io.Writer, fn func(fullName string, fi os.Fi
 		return err
 	}
 
-	basePath := path.Base(srcPath)
+	basePath := filepath.Base(srcPath)
 	if fi.IsDir() {
 		if includeDir {
 			if err = packFile(srcPath, basePath, zw, fi); err != nil {

--- a/zip/zip_test.go
+++ b/zip/zip_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -91,12 +93,15 @@ func TestAddEmptyDir(t *testing.T) {
 
 func TestAddDir(t *testing.T) {
 	Convey("Open a zip file and add dir with files", t, func() {
-		z, err := Create(path.Join(os.TempDir(), "testdata/TestAddDir.zip"))
+		z, err := Create(filepath.Join(os.TempDir(), "testdata/TestAddDir.zip"))
 		So(err, ShouldBeNil)
 
 		Convey("Add a dir that does exist", func() {
 			So(z.AddDir("testdata/testdir", "testdata/testdir"), ShouldBeNil)
-			So(strings.Join(z.List(), " "), ShouldEqual,
+
+			list := z.List()
+			sort.Strings(list)
+			So(strings.Join(list, " "), ShouldEqual,
 				"testdata/ testdata/testdir/ testdata/testdir/gophercolor16x16.png "+
 					"testdata/testdir/level1/ testdata/testdir/level1/README.txt")
 		})


### PR DESCRIPTION
To correctly handle path join, base and dir on Windows.

Part of https://github.com/gogs/gogs/issues/6339